### PR TITLE
Warn about using Eager APIs on TaskContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ Lazy APIs delay the realization of tasks until they're actually required, which 
 during the configuration phase since it can have a large impact on build performance. 
 Read more [here](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview)
 
-1. Any usage of `TaskContainer#all`. Use `configureEach` instead
-2. Any usage of `TaskContainer#create`. Use `register` instead
-3. Any usage of `TaskContainer#getByName`. Use `named` instead
+1. Any usage of `TaskContainer#all`. Use `configureEach` instead.
+2. Any usage of `TaskContainer#create`. Use `register` instead.
+3. Any usage of `TaskContainer#getByName`. Use `named` instead.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,13 @@ This will break the [configuration cache](https://docs.gradle.org/nightly/usergu
 `Project`s cannot be serialized.
 
 1. Usages of `getProject()` in the context of a method annotated with `@TaskAction`. 
+
+### Usages of eager APIs instead of lazy ones on the TaskContainer interface
+
+Lazy APIs delay the realization of tasks until they're actually required, which avoids doing intensive work 
+during the configuration phase since it can have a large impact on build performance. 
+Read more [here](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview)
+
+1. Any usage of `TaskContainer#all`. Use `configureEach` instead
+2. Any usage of `TaskContainer#create`. Use `register` instead
+3. Any usage of `TaskContainer#getByName`. Use `named` instead

--- a/plugin-best-practices-plugin/src/functionalTest/groovy/com/autonomousapps/fixture/SimplePluginProject.groovy
+++ b/plugin-best-practices-plugin/src/functionalTest/groovy/com/autonomousapps/fixture/SimplePluginProject.groovy
@@ -42,6 +42,7 @@ final class SimplePluginProject {
     newFile('src/main/java/com/test/GreetingPlugin.java').write('''\
       package com.test;
       
+      import org.gradle.api.tasks.TaskContainer;
       import org.gradle.api.Plugin;
       import org.gradle.api.Project;
       import java.util.*;
@@ -72,6 +73,13 @@ final class SimplePluginProject {
         
         private void bar() {
           project.getLogger().quiet("Foobar!");
+        }
+        
+        private void baz() {
+          TaskContainer tasks = project.getTasks();
+          tasks.create("eagerTask");
+          tasks.getByName("eagerTask");
+          tasks.all(task -> {});
         }
       }
     '''.stripIndent())
@@ -195,6 +203,15 @@ final class SimplePluginProject {
       com.test.GreetingPlugin#apply(Lorg.gradle.api.Project;)V ->
       org.gradle.api.Project#allprojects(Lorg.gradle.api.Action;)V
     
+    com.test.GreetingPlugin#baz()V ->
+      org.gradle.api.tasks.TaskContainer#getByName(Ljava.lang.String;)Lorg.gradle.api.Task;
+ 
+    com.test.GreetingPlugin#baz()V ->
+      org.gradle.api.tasks.TaskContainer#create(Ljava.lang.String;)Lorg.gradle.api.Task;
+ 
+    com.test.GreetingPlugin#baz()V ->
+      org.gradle.api.tasks.TaskContainer#all(Lorg.gradle.api.Action;)V
+ 
     com.test.GreetingPlugin#apply(Ljava.lang.Object;)V ->
       com.test.GreetingPlugin#apply(Lorg.gradle.api.Project;)V ->
       org.gradle.api.Project#getAllprojects()Ljava.util.Set;
@@ -228,6 +245,6 @@ final class SimplePluginProject {
   '''.stripIndent()
 
   String expectedBaseline = '''\
-    [{"type":"com.autonomousapps.issue.AllprojectsIssue","name":"allprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"allprojects","descriptor":"(Lorg/gradle/api/Action;)V"}]}},{"type":"com.autonomousapps.issue.GetAllprojectsIssue","name":"getAllprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"getAllprojects","descriptor":"()Ljava/util/Set;"}]}},{"type":"com.autonomousapps.issue.GetProjectInTaskActionIssue","name":"getProject","trace":{"trace":[{"owner":"com/test/FancyTask","name":"action","descriptor":"()V","metadata":{"isTaskAction":true}},{"owner":"com/test/FancyTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/FancyTask$ReallyFancyTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/FancyTask$ReallyFancyTask","name":"getProject","descriptor":"()Lorg/gradle/api/Project;"}]}},{"type":"com.autonomousapps.issue.GetProjectInTaskActionIssue","name":"getProject","trace":{"trace":[{"owner":"com/test/ParentTask","name":"action","descriptor":"()V","metadata":{"isTaskAction":true}},{"owner":"com/test/ParentTask","name":"foo","descriptor":"()V"},{"owner":"com/test/ParentTask","name":"bar","descriptor":"()V"},{"owner":"com/test/ParentTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask$ChildTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask$ChildTask","name":"getProject","descriptor":"()Lorg/gradle/api/Project;"}]}},{"type":"com.autonomousapps.issue.GetProjectInTaskActionIssue","name":"getProject","trace":{"trace":[{"owner":"com/test/ParentTask2","name":"action","descriptor":"()V","metadata":{"isTaskAction":true}},{"owner":"com/test/ParentTask2","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"foo","descriptor":"()V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"bar","descriptor":"([ILjava/lang/String;)V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"getProject","descriptor":"()Lorg/gradle/api/Project;"}]}},{"type":"com.autonomousapps.issue.GetSubprojectsIssue","name":"getSubprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"getSubprojects","descriptor":"()Ljava/util/Set;"}]}},{"type":"com.autonomousapps.issue.SubprojectsIssue","name":"subprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"subprojects","descriptor":"(Lorg/gradle/api/Action;)V"}]}}]
+    [{"type":"com.autonomousapps.issue.AllprojectsIssue","name":"allprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"allprojects","descriptor":"(Lorg/gradle/api/Action;)V"}]}},{"type":"com.autonomousapps.issue.EagerApiIssue","name":"eagerApis","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"baz","descriptor":"()V"},{"owner":"org/gradle/api/tasks/TaskContainer","name":"getByName","descriptor":"(Ljava/lang/String;)Lorg/gradle/api/Task;"}]}},{"type":"com.autonomousapps.issue.EagerApiIssue","name":"eagerApis","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"baz","descriptor":"()V"},{"owner":"org/gradle/api/tasks/TaskContainer","name":"create","descriptor":"(Ljava/lang/String;)Lorg/gradle/api/Task;"}]}},{"type":"com.autonomousapps.issue.EagerApiIssue","name":"eagerApis","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"baz","descriptor":"()V"},{"owner":"org/gradle/api/tasks/TaskContainer","name":"all","descriptor":"(Lorg/gradle/api/Action;)V"}]}},{"type":"com.autonomousapps.issue.GetAllprojectsIssue","name":"getAllprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"getAllprojects","descriptor":"()Ljava/util/Set;"}]}},{"type":"com.autonomousapps.issue.GetProjectInTaskActionIssue","name":"getProject","trace":{"trace":[{"owner":"com/test/FancyTask","name":"action","descriptor":"()V","metadata":{"isTaskAction":true}},{"owner":"com/test/FancyTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/FancyTask$ReallyFancyTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/FancyTask$ReallyFancyTask","name":"getProject","descriptor":"()Lorg/gradle/api/Project;"}]}},{"type":"com.autonomousapps.issue.GetProjectInTaskActionIssue","name":"getProject","trace":{"trace":[{"owner":"com/test/ParentTask","name":"action","descriptor":"()V","metadata":{"isTaskAction":true}},{"owner":"com/test/ParentTask","name":"foo","descriptor":"()V"},{"owner":"com/test/ParentTask","name":"bar","descriptor":"()V"},{"owner":"com/test/ParentTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask$ChildTask","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask$ChildTask","name":"getProject","descriptor":"()Lorg/gradle/api/Project;"}]}},{"type":"com.autonomousapps.issue.GetProjectInTaskActionIssue","name":"getProject","trace":{"trace":[{"owner":"com/test/ParentTask2","name":"action","descriptor":"()V","metadata":{"isTaskAction":true}},{"owner":"com/test/ParentTask2","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"doAction","descriptor":"()V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"foo","descriptor":"()V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"bar","descriptor":"([ILjava/lang/String;)V"},{"owner":"com/test/ParentTask2$ChildTask2","name":"getProject","descriptor":"()Lorg/gradle/api/Project;"}]}},{"type":"com.autonomousapps.issue.GetSubprojectsIssue","name":"getSubprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"getSubprojects","descriptor":"()Ljava/util/Set;"}]}},{"type":"com.autonomousapps.issue.SubprojectsIssue","name":"subprojects","trace":{"trace":[{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Ljava/lang/Object;)V"},{"owner":"com/test/GreetingPlugin","name":"apply","descriptor":"(Lorg/gradle/api/Project;)V"},{"owner":"org/gradle/api/Project","name":"subprojects","descriptor":"(Lorg/gradle/api/Action;)V"}]}}]
   '''.stripIndent()
 }

--- a/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/internal/analysis/IssueListener.kt
+++ b/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/internal/analysis/IssueListener.kt
@@ -335,7 +335,6 @@ internal class EagerApisListener : AbstractIssueListener() {
   override fun isSuspectNode(graph: Graph<MethodNode>, methodNode: MethodNode): Boolean {
     val methodOwner = methodNode.owner
     val methodName = methodNode.name
-    return eagerApis.containsKey(methodOwner) && eagerApis.getValue(methodOwner)
-      .contains(methodName)
+    return eagerApis[methodOwner]?.contains(methodName) ?: false
   }
 }

--- a/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/internal/analysis/IssueListener.kt
+++ b/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/internal/analysis/IssueListener.kt
@@ -7,6 +7,7 @@ import com.autonomousapps.internal.graphs.Class
 import com.autonomousapps.internal.graphs.Method
 import com.autonomousapps.internal.graphs.MethodNode
 import com.autonomousapps.issue.AllprojectsIssue
+import com.autonomousapps.issue.EagerApiIssue
 import com.autonomousapps.issue.GetAllprojectsIssue
 import com.autonomousapps.issue.GetProjectInTaskActionIssue
 import com.autonomousapps.issue.GetSubprojectsIssue
@@ -314,5 +315,27 @@ internal class GetProjectListener : AbstractIssueListener() {
 
   override fun methodMetadata(): MethodNode.Metadata {
     return MethodNode.Metadata(isTaskAction)
+  }
+}
+
+/** Invokes Eager APIs instead of Lazy ones.
+ * @see <a href="https://docs.gradle.org/current/userguide/lazy_configuration.html">Lazy Configuration</a>
+ * @see <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview">Old vs New API Overview</a>
+ */
+internal class EagerApisListener : AbstractIssueListener() {
+
+  private val eagerApis = mapOf(
+    "org/gradle/api/tasks/TaskContainer" to setOf("all", "create", "getByName")
+  )
+
+  override fun computeIssues(): Set<Issue> = computeTraces().mapTo(HashSet()) { trace ->
+    EagerApiIssue("eagerApis", trace)
+  }
+
+  override fun isSuspectNode(graph: Graph<MethodNode>, methodNode: MethodNode): Boolean {
+    val methodOwner = methodNode.owner
+    val methodName = methodNode.name
+    return eagerApis.containsKey(methodOwner) && eagerApis.getValue(methodOwner)
+      .contains(methodName)
   }
 }

--- a/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/issue/Issue.kt
+++ b/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/issue/Issue.kt
@@ -37,3 +37,9 @@ data class GetProjectInTaskActionIssue(
   override val name: String,
   override val trace: Trace
 ) : Issue()
+
+@Serializable
+data class EagerApiIssue(
+  override val name: String,
+  override val trace: Trace
+) : Issue()

--- a/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/task/CheckBestPracticesTask.kt
+++ b/plugin-best-practices-plugin/src/main/kotlin/com/autonomousapps/task/CheckBestPracticesTask.kt
@@ -3,6 +3,7 @@ package com.autonomousapps.task
 import com.autonomousapps.internal.analysis.AllProjectsListener
 import com.autonomousapps.internal.analysis.ClassAnalyzer
 import com.autonomousapps.internal.analysis.CompositeIssueListener
+import com.autonomousapps.internal.analysis.EagerApisListener
 import com.autonomousapps.internal.analysis.GetAllprojectsListener
 import com.autonomousapps.internal.analysis.GetProjectListener
 import com.autonomousapps.internal.analysis.GetSubprojectsListener
@@ -212,6 +213,7 @@ abstract class CheckBestPracticesTask @Inject constructor(
         SubprojectsListener(),
         GetSubprojectsListener(),
         GetProjectListener(),
+        EagerApisListener(),
       )
       return CompositeIssueListener(listeners)
     }


### PR DESCRIPTION
Adds a new `EagerApiIssue` to warn users about invoking eager APIs on Gradle's container types. Currently, it only warns about invoking `TaskContainer#all`, `TaskContainer#create`, and `TaskContainer#getByName`. 