### PR TITLE
Add a GitHub Action that runs checks on every PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: plugin-best-practices-plugin:check -s
+          arguments: check -s

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Run tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: plugin-best-practices-plugin:check -s


### PR DESCRIPTION
Just wanted to get the ball rolling on this. Fairly simple stuff for now, feel free to add more steps like saving artifacts, etc. I've chosen to use the [Gradle Build Action](https://github.com/gradle/gradle-build-action) because in my testing on another project, it was a lot more robust at caching when compared to `actions/cache@v2` (i.e., it actually worked). 